### PR TITLE
feat: #18 회원가입 input, textarea react-hook-form 사용 예시 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,8 @@
       {
         "endOfLine": "auto"
       }
-    ]
+    ],
+    "require-jsdoc": "off",
+    "valid-jsdoc": "off"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "next": "15.0.0-rc.0",
     "react": "19.0.0-rc-e4953922-20240919",
     "react-dom": "19.0.0-rc-e4953922-20240919",
+    "react-hook-form": "^7.53.1",
     "zustand": "5.0.0-rc.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       react-dom:
         specifier: 19.0.0-rc-e4953922-20240919
         version: 19.0.0-rc-e4953922-20240919(react@19.0.0-rc-e4953922-20240919)
+      react-hook-form:
+        specifier: ^7.53.1
+        version: 7.53.1(react@19.0.0-rc-e4953922-20240919)
       zustand:
         specifier: 5.0.0-rc.2
         version: 5.0.0-rc.2(@types/react@18.3.7)(react@19.0.0-rc-e4953922-20240919)
@@ -4414,6 +4417,12 @@ packages:
     peerDependencies:
       react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
       react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
+
+  react-hook-form@7.53.1:
+    resolution: {integrity: sha512-6aiQeBda4zjcuaugWvim9WsGqisoUk+etmFEsSUMm451/Ic8L/UAb7sRtMj3V+Hdzm6mMjU1VhiSzYUZeBm0Vg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -10319,6 +10328,10 @@ snapshots:
       react: 19.0.0-rc-e4953922-20240919
       react-dom: 19.0.0-rc-e4953922-20240919(react@19.0.0-rc-e4953922-20240919)
       react-is: 18.1.0
+
+  react-hook-form@7.53.1(react@19.0.0-rc-e4953922-20240919):
+    dependencies:
+      react: 19.0.0-rc-e4953922-20240919
 
   react-is@16.13.1: {}
 

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+import { DefaultLayout } from 'components/layout';
+import { Organization } from 'components/feature/register';
+
+export default function Register() {
+  return (
+    <DefaultLayout>
+      <Organization />
+    </DefaultLayout>
+  );
+}

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -2,28 +2,14 @@
 import { buttonVariant } from 'types';
 import * as S from './Button.styled';
 
-interface ButtonProps {
-  children?: React.ReactNode;
-  className?: string;
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: buttonVariant;
-  disabled?: boolean;
   handleClick?: () => void;
 }
 
-const Button = ({
-  className,
-  children,
-  variant,
-  disabled,
-  handleClick,
-}: ButtonProps) => {
+const Button = ({ children, variant, handleClick, ...rest }: ButtonProps) => {
   return (
-    <S.Button
-      className={className}
-      variant={variant}
-      disabled={disabled}
-      onClick={handleClick}
-    >
+    <S.Button variant={variant} onClick={handleClick} {...rest}>
       {children}
     </S.Button>
   );

--- a/src/components/controller/TextController.tsx
+++ b/src/components/controller/TextController.tsx
@@ -1,0 +1,49 @@
+import { Controller, Control, RegisterOptions } from 'react-hook-form';
+import { Input } from 'components/input';
+
+interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
+  name: string;
+  control: Control<any>;
+  rules?: RegisterOptions;
+  handleFocus?: (e: React.FocusEvent<HTMLInputElement>) => void;
+  handleBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
+  handleChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  hasError?: boolean;
+}
+
+export default function TextController({
+  name,
+  control,
+  rules,
+  handleFocus,
+  handleBlur,
+  handleChange,
+  handleKeyDown,
+  hasError,
+  ...rest
+}: Props) {
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={rules}
+      render={({ field, fieldState }) => (
+        <Input
+          {...field}
+          handleFocus={handleFocus}
+          handleBlur={handleBlur}
+          handleChange={(e) => {
+            field.onChange(e);
+            if (handleChange) {
+              handleChange(e);
+            }
+          }}
+          handleKeyDown={handleKeyDown}
+          hasError={hasError || !!fieldState.error}
+          {...rest}
+        />
+      )}
+    />
+  );
+}

--- a/src/components/controller/TextareaController.tsx
+++ b/src/components/controller/TextareaController.tsx
@@ -1,0 +1,38 @@
+import { Controller, Control, RegisterOptions } from 'react-hook-form';
+import { Textarea } from 'components/input';
+
+interface Props extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  name: string;
+  control: Control<any>;
+  rules?: RegisterOptions;
+  handleChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  handleFocus?: (e: React.FocusEvent<HTMLTextAreaElement>) => void;
+  handleBlur?: (e: React.FocusEvent<HTMLTextAreaElement>) => void;
+}
+
+export default function TextareaController({
+  name,
+  control,
+  rules,
+  handleChange,
+  handleBlur,
+  handleFocus,
+  ...rest
+}: Props) {
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={rules}
+      render={({ field }) => (
+        <Textarea
+          {...field}
+          handleBlur={handleBlur}
+          handleChange={handleChange}
+          handleFocus={handleFocus}
+          {...rest}
+        />
+      )}
+    />
+  );
+}

--- a/src/components/controller/index.ts
+++ b/src/components/controller/index.ts
@@ -1,0 +1,2 @@
+export { default as TextController } from './TextController';
+export { default as TextareaController } from './TextAreaController';

--- a/src/components/feature/register/Organization.styled.ts
+++ b/src/components/feature/register/Organization.styled.ts
@@ -1,0 +1,22 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+export const ContentBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+export const InputBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+`;
+
+export const Label = styled.h2``;

--- a/src/components/feature/register/Organization.tsx
+++ b/src/components/feature/register/Organization.tsx
@@ -1,0 +1,64 @@
+import { useForm, SubmitHandler, SubmitErrorHandler } from 'react-hook-form';
+import * as S from './Organization.styled';
+import { TextController, TextareaController } from 'components/controller';
+import { Button } from 'components/button';
+
+interface FormData {
+  companyName: string;
+  jobTitle: string;
+  description: string;
+}
+
+export default function Organization() {
+  const { handleSubmit, control } = useForm<FormData>({
+    defaultValues: {
+      companyName: '',
+      jobTitle: '',
+      description: '',
+    },
+  });
+
+  const onSumbit: SubmitHandler<FormData> = (data) => {
+    console.log(data);
+  };
+
+  const onErrors: SubmitErrorHandler<FormData> = (errors) => {
+    console.log(errors);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSumbit, onErrors)}>
+      <S.Container>
+        <S.ContentBox>
+          <S.InputBox>
+            <S.Label>직장</S.Label>
+            <TextController
+              name="companyName"
+              control={control}
+              rules={{ required: true, minLength: 2, maxLength: 15 }}
+              placeholder="삼성전자, 현대 자동차, 네이버 등"
+            />
+          </S.InputBox>
+          <S.InputBox>
+            <S.Label>직업</S.Label>
+            <TextController
+              name="jobTitle"
+              control={control}
+              rules={{ required: true, minLength: 2, maxLength: 15 }}
+              placeholder="의사, 개발자, 공무원, 은행원 등"
+            />
+          </S.InputBox>
+          <S.InputBox>
+            <S.Label>설명</S.Label>
+            <TextareaController
+              name="description"
+              control={control}
+              placeholder="직업 관련 설명해주세요."
+            />
+          </S.InputBox>
+        </S.ContentBox>
+        <Button type="submit">저장</Button>
+      </S.Container>
+    </form>
+  );
+}

--- a/src/components/feature/register/index.ts
+++ b/src/components/feature/register/index.ts
@@ -1,0 +1,1 @@
+export { default as Organization } from './Organization';

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import * as S from './Input.styled';
 
-interface InputProps {
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   className?: string;
   hasError?: boolean;
   handleFocus?: (e: React.FocusEvent<HTMLInputElement>) => void;

--- a/src/components/input/textarea/Textarea.tsx
+++ b/src/components/input/textarea/Textarea.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import * as S from './Textarea.styled';
 
-interface TextareaProps {
+interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   className?: string;
   handleChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   handleFocus?: (e: React.FocusEvent<HTMLTextAreaElement>) => void;

--- a/src/components/layout/DefaultLayout.tsx
+++ b/src/components/layout/DefaultLayout.tsx
@@ -1,0 +1,13 @@
+import * as S from './Layout.styled';
+
+interface Props {
+  children?: React.ReactNode;
+}
+
+/**
+ * DefaultLayout을 반환하는 컴포넌트
+ * @return {JSX}
+ */
+export default function DefaultLayout({ children }: Props) {
+  return <S.DefaultLayout>{children}</S.DefaultLayout>;
+}

--- a/src/components/layout/Layout.styled.ts
+++ b/src/components/layout/Layout.styled.ts
@@ -1,0 +1,28 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const DefaultLayout = styled.section`
+  ${({ theme }) => css`
+    width: 100%;
+    padding: 16px;
+
+    /* 기본 모바일 스타일 */
+    max-width: 480px;
+    margin: 0 auto;
+
+    /* 태블릿 크기 이상일 때 */
+    @media (min-width: 768px) {
+      max-width: 720px;
+    }
+
+    /* 데스크탑 크기 이상일 때 */
+    @media (min-width: 1024px) {
+      max-width: 960px;
+    }
+
+    /* 대형 데스크탑 크기 이상일 때 */
+    @media (min-width: 1440px) {
+      max-width: 1200px;
+    }
+  `}
+`;

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,0 +1,2 @@
+export * from './Layout.styled';
+export { default as DefaultLayout } from './DefaultLayout';


### PR DESCRIPTION
## 💛 ISSUE 번호

- #18

<br/>

## 💙 작업 내용

- textController 생성 (input 관련 hook form 공통 컴포넌트)
- textareaController 생성 ( textarea 관련 hook form 공통 컴포넌트)
- 예시 회원가입 직장 기입 화면 생성

<br/>

## 💜 참고 사항

- Button, Input, Textarea 공통 컴포넌트 기본 타입을 확장하기 위해 수정
- ESLINT jsdoc 생성 룰 끄기
