### PR TITLE
Feat/#68 미팅만들기api연동

### DIFF
--- a/src/api/meeting.ts
+++ b/src/api/meeting.ts
@@ -1,4 +1,4 @@
-import { CreateMeetingReq } from 'types';
+import { CommonResp, CreateMeetingReq, MeetingListRes } from 'types';
 import { httpClient } from './axios';
 
 const MEETING_API = '/api/v1/meeting';
@@ -26,4 +26,16 @@ export const postCreateMeetingAPI = async (payload: CreateMeetingReq) => {
   });
 
   return data;
+};
+
+/**
+ * @summary Meeting 리스트 조회
+ * @request GET:/api/v1/meeting/list
+ */
+export const getMeetingListAPI = async () => {
+  const { data } = await httpClient.get<CommonResp<MeetingListRes>>(
+    `${MEETING_API}/list?page=1&size=5`
+  );
+
+  return data.data;
 };

--- a/src/api/region.ts
+++ b/src/api/region.ts
@@ -1,4 +1,4 @@
-import { CommonResp, regionRes } from 'types';
+import { CommonResp, RegionRes } from 'types';
 import { httpClient } from './axios';
 
 /**
@@ -7,7 +7,7 @@ import { httpClient } from './axios';
  */
 export const getRegionStateAPI = async () => {
   const { data } =
-    await httpClient.get<CommonResp<regionRes[]>>(`/api/v1/region`);
+    await httpClient.get<CommonResp<RegionRes[]>>(`/api/v1/region`);
   return data;
 };
 
@@ -16,7 +16,7 @@ export const getRegionStateAPI = async () => {
  * @request GET:/api/v1/region/{parentId}
  */
 export const getRegionCityAPI = async (parentId: number) => {
-  const { data } = await httpClient.get<CommonResp<regionRes[]>>(
+  const { data } = await httpClient.get<CommonResp<RegionRes[]>>(
     `/api/v1/region/${parentId}`
   );
   return data;

--- a/src/app/ClientProviders.tsx
+++ b/src/app/ClientProviders.tsx
@@ -4,6 +4,7 @@ import { Global, ThemeProvider } from '@emotion/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { DialogProvider } from 'components/Dialog';
 import { globalStyle, theme } from 'styles';
+import { Toast } from 'components';
 
 const ClientProviders = ({ children }: { children: React.ReactNode }) => {
   const queryClient = new QueryClient();
@@ -13,6 +14,7 @@ const ClientProviders = ({ children }: { children: React.ReactNode }) => {
       <ThemeProvider theme={theme}>
         <DialogProvider>
           <Global styles={globalStyle} />
+          <Toast />
           {children}
         </DialogProvider>
       </ThemeProvider>

--- a/src/app/createMeeting/containers/CreateMeetingRoom/CreateMeetingRoom.tsx
+++ b/src/app/createMeeting/containers/CreateMeetingRoom/CreateMeetingRoom.tsx
@@ -17,9 +17,14 @@ import { usePostCreateMeeting } from 'hooks';
 interface CreateMeetingRoomProps {
   step: number;
   setStep: React.Dispatch<React.SetStateAction<number>>;
+  setMeetingId: React.Dispatch<React.SetStateAction<number>>;
 }
 
-const CreateMeetingRoom = ({ step, setStep }: CreateMeetingRoomProps) => {
+const CreateMeetingRoom = ({
+  step,
+  setStep,
+  setMeetingId,
+}: CreateMeetingRoomProps) => {
   const { control, watch, handleSubmit, setValue } =
     useFormContext<CreateMeetingForm>();
   const title = watch('title');
@@ -77,7 +82,8 @@ const CreateMeetingRoom = ({ step, setStep }: CreateMeetingRoomProps) => {
           image: image,
         },
         {
-          onSuccess: () => {
+          onSuccess: (res) => {
+            setMeetingId(res.data.meetingId);
             setStep(step + 1);
           },
           onError: (error) => {

--- a/src/app/createMeeting/containers/inviteFriends/InviteFriends.tsx
+++ b/src/app/createMeeting/containers/inviteFriends/InviteFriends.tsx
@@ -5,6 +5,7 @@ import { ButtonFooter, ProfileCard, RadioCard } from 'components';
 import { inviteFriendsRadioList } from 'assets';
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import useToastStore from 'store/toastStore';
 
 interface InviteFriendsProps {
   meetingId: number;
@@ -13,6 +14,7 @@ interface InviteFriendsProps {
 const InviteFriends = ({ meetingId }: InviteFriendsProps) => {
   const { control, watch, setValue, handleSubmit } =
     useFormContext<CreateMeetingForm>();
+  const { setToast } = useToastStore();
   const withFriends = watch('withFriends');
   const inviteFriends = watch('inviteFriends');
   const isNextButtonEnabled =
@@ -29,6 +31,8 @@ const InviteFriends = ({ meetingId }: InviteFriendsProps) => {
   const handleClickNext = () => {
     if (isNextButtonEnabled && meetingId) {
       router.push(`/meeting/${meetingId}`);
+      // TODO: test 필요
+      setToast('미팅 방이 성공적으로 생성되었습니다.');
       console.log('완료');
     }
   };

--- a/src/app/createMeeting/containers/inviteFriends/InviteFriends.tsx
+++ b/src/app/createMeeting/containers/inviteFriends/InviteFriends.tsx
@@ -4,8 +4,13 @@ import * as S from './InviteFriends.styled';
 import { ButtonFooter, ProfileCard, RadioCard } from 'components';
 import { inviteFriendsRadioList } from 'assets';
 import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 
-const InviteFriends = () => {
+interface InviteFriendsProps {
+  meetingId: number;
+}
+
+const InviteFriends = ({ meetingId }: InviteFriendsProps) => {
   const { control, watch, setValue, handleSubmit } =
     useFormContext<CreateMeetingForm>();
   const withFriends = watch('withFriends');
@@ -13,6 +18,7 @@ const InviteFriends = () => {
   const isNextButtonEnabled =
     withFriends === 'N' ||
     (inviteFriends !== undefined && inviteFriends?.length > 0);
+  const router = useRouter();
 
   useEffect(() => {
     if (withFriends === 'N') {
@@ -20,9 +26,9 @@ const InviteFriends = () => {
     }
   }, [withFriends]);
 
-  const handleClickNext = (data: CreateMeetingForm) => {
-    console.log('data', data);
-    if (isNextButtonEnabled) {
+  const handleClickNext = () => {
+    if (isNextButtonEnabled && meetingId) {
+      router.push(`/meeting/${meetingId}`);
       console.log('완료');
     }
   };

--- a/src/app/createMeeting/page.tsx
+++ b/src/app/createMeeting/page.tsx
@@ -13,6 +13,7 @@ import { createMeetingDefaultValues } from 'assets';
 
 const CreateMeeting = () => {
   const [step, setStep] = useState(0);
+  const [meetingId, setMeetingId] = useState<number>(0);
 
   const methods = useForm<CreateMeetingForm>({
     defaultValues: createMeetingDefaultValues,
@@ -21,9 +22,15 @@ const CreateMeeting = () => {
   const renderPage = (step: number) => {
     switch (step) {
       case 0:
-        return <CreateMeetingRoom step={step} setStep={setStep} />;
+        return (
+          <CreateMeetingRoom
+            step={step}
+            setStep={setStep}
+            setMeetingId={setMeetingId}
+          />
+        );
       case 1:
-        return <InviteFriends />;
+        return <InviteFriends meetingId={meetingId} />;
       // TODO: 다른 방법 있나 생각해보기
       case 999:
         return <DefaultImageSelect setStep={setStep} />;

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -1,10 +1,16 @@
 'use client';
 import { DefaultLayout, HomeFooter } from 'components';
+import { useGetMeetingList } from 'hooks';
+import { useRouter } from 'next/navigation';
 import useUserStore from 'store/userStore';
+import { MeetingListItem } from 'types';
 
 const Main = () => {
   const user = useUserStore((state) => state.user);
+  const { data: meetingList } = useGetMeetingList();
+  const router = useRouter();
   console.log('user', user);
+  console.log('meetingList', meetingList);
   return (
     <DefaultLayout>
       Home
@@ -12,6 +18,25 @@ const Main = () => {
       <div>UserId: {user?.userId}</div>
       <div>WorkThroughStep: {user?.workThroughStep}</div>
       <div>nickname: {user?.userDetailResponseDto.nickname}</div>
+      <div>MeetingList</div>
+      {meetingList &&
+        meetingList.items.map((item: MeetingListItem) => (
+          <div
+            key={item.meetingId}
+            style={{ height: '50px', border: '1px solid black' }}
+            onClick={() => router.push(`/meeting/${item.meetingId}`)}
+          >
+            <div>meetingId: {item?.meetingId}</div>
+            <div>title: {item?.title}</div>
+            <div>
+              image:
+              <img
+                style={{ height: '24px', width: '24px' }}
+                src={item?.meetingImage}
+              />
+            </div>
+          </div>
+        ))}
       <HomeFooter />
     </DefaultLayout>
   );

--- a/src/components/toast/Toast.styled.ts
+++ b/src/components/toast/Toast.styled.ts
@@ -1,35 +1,48 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import * as Toast from '@radix-ui/react-toast';
 
+export const ToastWrapper = styled.div`
+  position: fixed;
+  bottom: 104px;
+  min-height: 44px;
+  pointer-events: none;
+  min-width: 328px;
+  z-index: 10000000;
+  left: 0;
+  right: 0;
+  padding: 0 16px;
+`;
+
 // Toast Root
 export const ToastRoot = styled(Toast.Root)`
-  background-color: #333;
-  color: white;
-  border-radius: 8px;
-  padding: 16px;
-  font-size: 14px;
-  display: flex;
-  align-items: center;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-  max-width: 300px;
-  animation: fadeIn 300ms ease-out;
+  ${({ theme }) => css`
+    background-color: ${theme.colors.gray80};
+    color: ${theme.colors.gray0};
+    border-radius: 12px;
+    padding: 12px;
+    display: flex;
+    align-items: center;
+    animation: fadeIn 300ms ease-out;
 
-  @keyframes fadeIn {
-    from {
-      opacity: 0;
-      transform: translateY(10px);
+    @keyframes fadeIn {
+      from {
+        opacity: 0;
+        transform: translateY(10px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
     }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
+  `}
 `;
 
 // Toast Title
 export const ToastTitle = styled(Toast.Title)`
-  font-weight: bold;
-  margin-right: 8px;
+  ${({ theme }) => css`
+    ${theme.fonts.body_14_M}
+  `}
 `;
 
 // Toast Description (optional)

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -1,35 +1,29 @@
-import { useState, useRef, useEffect } from 'react';
 import * as S from './Toast.styled';
 import * as ToastPopup from '@radix-ui/react-toast';
+import { useEffect, useRef } from 'react';
+import useToastStore from 'store/toastStore';
 
 const Toast = () => {
-  const [open, setOpen] = useState(false);
+  const { message, openToast, closeToast } = useToastStore();
   const timerRef = useRef(0);
 
   useEffect(() => {
+    if (openToast) {
+      timerRef.current = window.setTimeout(() => {
+        closeToast();
+      }, 3000);
+    }
     return () => clearTimeout(timerRef.current);
-  }, []);
+  }, [openToast, closeToast]);
 
   return (
     <ToastPopup.Provider>
-      <button
-        onClick={() => {
-          setOpen(false);
-          window.clearTimeout(timerRef.current);
-          timerRef.current = window.setTimeout(() => {
-            setOpen(true);
-          }, 100);
-        }}
-      >
-        Show Toast
-      </button>
-      <S.ToastRoot open={open} onOpenChange={setOpen}>
-        <S.ToastTitle>This is a simple toast notification.</S.ToastTitle>
-        <S.ToastAction asChild altText="Close">
-          <button onClick={() => setOpen(false)}>Close</button>
-        </S.ToastAction>
-      </S.ToastRoot>
-      <ToastPopup.Viewport />
+      <S.ToastWrapper>
+        <S.ToastRoot open={openToast} onOpenChange={closeToast}>
+          <S.ToastTitle>{message}</S.ToastTitle>
+        </S.ToastRoot>
+        <ToastPopup.Viewport />
+      </S.ToastWrapper>
     </ToastPopup.Provider>
   );
 };

--- a/src/hooks/queries/meeting.ts
+++ b/src/hooks/queries/meeting.ts
@@ -1,6 +1,6 @@
-import { useMutation } from '@tanstack/react-query';
-import { postCreateMeetingAPI } from 'api/meeting';
-import { CreateMeetingReq } from 'types';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { getMeetingListAPI, postCreateMeetingAPI } from 'api/meeting';
+import { CreateMeetingReq, MeetingListRes } from 'types';
 
 /**
  * @summary Meeting 생성
@@ -9,5 +9,16 @@ import { CreateMeetingReq } from 'types';
 export const usePostCreateMeeting = () => {
   return useMutation({
     mutationFn: (req: CreateMeetingReq) => postCreateMeetingAPI(req),
+  });
+};
+
+/**
+ * @summary Meeting 리스트 조회
+ * @request GET:/api/v1/meeting/list
+ */
+export const useGetMeetingList = () => {
+  return useQuery<MeetingListRes>({
+    queryKey: ['meetingList'],
+    queryFn: () => getMeetingListAPI(),
   });
 };

--- a/src/hooks/queries/region.ts
+++ b/src/hooks/queries/region.ts
@@ -1,13 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 import { getRegionCityAPI, getRegionStateAPI } from 'api/region';
-import { CommonResp, regionRes } from 'types';
+import { CommonResp, RegionRes } from 'types';
 
 /**
  * @summary Region [시,도] 조회
  * @request GET:/api/v1/region
  */
 export const useGetRegionState = () => {
-  return useQuery<CommonResp<regionRes[]>>({
+  return useQuery<CommonResp<RegionRes[]>>({
     queryKey: ['region'],
     queryFn: () => getRegionStateAPI(),
   });
@@ -18,7 +18,7 @@ export const useGetRegionState = () => {
  * @request GET:/api/v1/region/{parentId}
  */
 export const useGetRegionCity = (parentId: number) => {
-  return useQuery<CommonResp<regionRes[]>>({
+  return useQuery<CommonResp<RegionRes[]>>({
     queryKey: ['region', parentId],
     queryFn: () => getRegionCityAPI(parentId),
     enabled: !!parentId,

--- a/src/store/toastStore.ts
+++ b/src/store/toastStore.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+interface ToastState {
+  message: string;
+  openToast: boolean;
+  setToast: (message: string) => void;
+  closeToast: () => void;
+}
+
+const useToastStore = create<ToastState>((set) => ({
+  message: '',
+  openToast: false,
+  setToast: (message) => set({ message: message, openToast: true }),
+  closeToast: () => set({ openToast: false }),
+}));
+
+export default useToastStore;

--- a/src/types/api/meeting.ts
+++ b/src/types/api/meeting.ts
@@ -8,3 +8,30 @@ export interface CreateMeetingReq {
   };
   image?: File | string;
 }
+
+export interface MeetingListItem {
+  content: string;
+  hashtags: string[];
+  meetingId: number;
+  meetingImage: string;
+  numberOfAttendance: number;
+  numberOfFemaleAttendance: number;
+  numberOfMaleAttendance: number;
+  region: {
+    regionId: number;
+    name: string;
+    parentId: number;
+    parentName: string;
+  };
+  status: 'NONE' | 'OPEN' | 'CLOSE' | string;
+  title: string;
+  type: 'DOUBLE' | 'TRIPLE' | 'QUADRUPLE' | string;
+}
+
+export interface MeetingListRes {
+  items: MeetingListItem[];
+  totalPages: number;
+  totalElements: number;
+  isFirst: boolean;
+  isLast: boolean;
+}

--- a/src/types/api/region.ts
+++ b/src/types/api/region.ts
@@ -1,4 +1,4 @@
-export interface regionRes {
+export interface RegionRes {
   regionId: number;
   name: string;
   parentId: number | null;


### PR DESCRIPTION
## 💛 ISSUE 번호

- #68

<br/>

## 💙 작업 내용

- 미팅만들기 api 연동, meetingId 받아서 detail로 넘기기 (/meeting/${meetingId})
- toast css 수정, zustand 전역으로 처리
- meeting list api 연동 

<br/>

## 💜 참고 사항

- 미팅방 각각의 detail값을 get 해오는 api가 없는 것 같아서 우선 main에서 list 띄우고 클릭하면 detail로 넘어가게끔만 해놨습니다.
- 방장 아닌 사람은 그 이후에 처리 해야할 것 같아서 우선 여기까지만 올립니다.
